### PR TITLE
Add XPath filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "pestphp/pest": "^2.24",
         "spatie/ray": "^1.39"
     },
+    "suggest": {
+        "ext-dom": "Required for filtering HTML.",
+        "ext-libxml": "Required for filtering HTML."
+    },
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ use Stevebauman\Hypertext\Transformer;
 
 $transformer = new Transformer();
 
+// (Optional) Filter out specific elements by their XPath.
+$transformer->filter("//*[@id='some-element']");
+
 // (Optional) Retain new line characters.
 $transformer->keepNewLines();
 

--- a/tests/Fixtures/laravel.com/output-filter-xpath.txt
+++ b/tests/Fixtures/laravel.com/output-filter-xpath.txt
@@ -1,0 +1,67 @@
+Laravel is a web application framework with expressive, elegant syntax. We believe development must
+be an enjoyable and creative experience to be truly fulfilling. Laravel attempts to take the pain
+out of development by easing common tasks used in most web projects.
+Highlights
+<a href="/team">Our Team</a>
+<a href="/docs/10.x/releases">Release Notes</a>
+<a href="/docs/10.x/installation">Getting Started</a>
+<a href="/docs/10.x/routing">Routing</a>
+<a href="/docs/10.x/blade">Blade Templates</a>
+<a href="/docs/10.x/authentication">Authentication</a>
+<a href="/docs/10.x/authorization">Authorization</a>
+<a href="/docs/10.x/artisan">Artisan Console</a>
+<a href="/docs/10.x/database">Database</a>
+<a href="/docs/10.x/eloquent">Eloquent ORM</a>
+<a href="/docs/10.x/testing">Testing</a>
+Resources
+<a href="https://bootcamp.laravel.com">Laravel Bootcamp</a>
+<a href="https://laracasts.com">Laracasts</a>
+<a href="https://laravel-news.com">Laravel News</a>
+<a href="https://laracon.us">Laracon</a>
+<a href="https://laracon.au">Laracon AU</a>
+<a href="https://laracon.eu/">Laracon EU</a>
+<a href="https://laracon.in/">Laracon India</a>
+<a href="https://larabelles.com/">Larabelles</a>
+<a href="https://larajobs.com">Jobs</a>
+<a href="https://laracasts.com/discuss">Forums</a>
+<a href="https://laravel.bigcartel.com/products">Shop</a>
+<a href="/trademark">Trademark</a>
+Partners
+<a href="https://vehikl.com">Vehikl</a>
+<a href="https://webreinvent.com/?utm_source=laravel&amp;utm_medium=laravel.com&amp;utm_campaign=footer-link">WebReinvent</a>
+<a href="https://tighten.co">Tighten</a>
+<a href="https://www.bacancytechnology.com/hire-laravel-developer?utm_source=laravel&amp;utm_medium=partners.laravel&amp;utm_campaign=sponsors">Bacancy</a>
+<a href="https://64robots.com/">64 Robots</a>
+<a href="https://activelogic.com/">Active Logic</a>
+<a href="https://www.byte5.net/">Byte 5</a>
+<a href="https://www.curotec.com/services/technologies/laravel/">Curotec</a>
+<a href="https://www.cyber-duck.co.uk/how-we-work/technology/laravel?utm_source=Laravel%20Partner&amp;utm_medium=Sponsorship">Cyber-Duck</a>
+<a href="https://devsquad.com/">DevSquad</a>
+<a href="https://jump24.co.uk/">Jump24</a>
+<a href="https://kirschbaumdevelopment.com/">Kirschbaum</a>
+Ecosystem
+<a href="/docs/10.x/starter-kits#laravel-breeze">Breeze</a>
+<a href="/docs/10.x/billing">Cashier</a>
+<a href="/docs/10.x/dusk">Dusk</a>
+<a href="/docs/10.x/broadcasting">Echo</a>
+<a href="https://envoyer.io">Envoyer</a>
+<a href="https://forge.laravel.com">Forge</a>
+<a href="https://herd.laravel.com">Herd</a>
+<a href="/docs/10.x/horizon">Horizon</a>
+<a href="https://inertiajs.com">Inertia</a>
+<a href="https://jetstream.laravel.com">Jetstream</a>
+<a href="https://livewire.laravel.com">Livewire</a>
+<a href="https://nova.laravel.com">Nova</a>
+<a href="/docs/10.x/octane">Octane</a>
+<a href="/docs/10.x/pennant">Pennant</a>
+<a href="/docs/10.x/pint">Pint</a>
+<a href="/docs/10.x/prompts">Prompts</a>
+<a href="/docs/10.x/sail">Sail</a>
+<a href="/docs/10.x/sanctum">Sanctum</a>
+<a href="/docs/10.x/scout">Scout</a>
+<a href="/docs/10.x/socialite">Socialite</a>
+<a href="https://spark.laravel.com">Spark</a>
+<a href="/docs/10.x/telescope">Telescope</a>
+<a href="https://vapor.laravel.com">Vapor</a>
+Laravel is a Trademark of Taylor Otwell. Copyright © 2011-2023 Laravel LLC.
+Code highlighting provided by <a href="https://torchlight.dev">Torchlight</a>

--- a/tests/Unit/TransformerTest.php
+++ b/tests/Unit/TransformerTest.php
@@ -116,3 +116,18 @@ it('captures text within html', function (string $inputFile, string $outputFile,
         fn (Transformer $transformer) => $transformer->keepNewLines(),
     ],
 ]);
+
+it('it captures text only within selector', function () {
+    expect(
+        transformer()->filterXPath('//a')->toText(<<<HTML
+        <div>foo</div><a>bar</a><p>baz</p>
+        HTML)
+    )->toEqual('bar');
+});
+
+it('it captures text only within selector with larger input', function () {
+    $input = file_get_contents(fixture('laravel.com/input.txt'));
+    $output = file_get_contents(fixture('laravel.com/output-filter-xpath.txt'));
+
+    expect(transformer()->filterXPath('//footer')->keepLinks()->keepNewLines()->toText($input))->toEqual($output);
+});

--- a/tests/Unit/TransformerTest.php
+++ b/tests/Unit/TransformerTest.php
@@ -117,17 +117,17 @@ it('captures text within html', function (string $inputFile, string $outputFile,
     ],
 ]);
 
-it('it captures text only within selector', function () {
+it('it captures text only within filter selector', function () {
     expect(
-        transformer()->filterXPath('//a')->toText(<<<HTML
+        transformer()->filter('//a')->toText(<<<HTML
         <div>foo</div><a>bar</a><p>baz</p>
         HTML)
     )->toEqual('bar');
 });
 
-it('it captures text only within selector with larger input', function () {
+it('it captures text only within filter selector with larger input', function () {
     $input = file_get_contents(fixture('laravel.com/input.txt'));
     $output = file_get_contents(fixture('laravel.com/output-filter-xpath.txt'));
 
-    expect(transformer()->filterXPath('//footer')->keepLinks()->keepNewLines()->toText($input))->toEqual($output);
+    expect(transformer()->filter('//footer')->keepLinks()->keepNewLines()->toText($input))->toEqual($output);
 });


### PR DESCRIPTION
Thank you for creating this package. I am using it in an application that crawls websites to feed them to an LLM. Sometimes I want to filter down the HTML to just a specific element or set of elements. I can implement this in my own code but thought this might be useful for everyone. 

I'm not sure what to think about warning suppression with `libxml_use_internal_errors`, but this was necessary to suppress warnings from loading the Laravel.com fixtures.

Please let me know what you think, I can also update the readme if you would consider merging this.